### PR TITLE
adds support of smartctl input

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 # -*- mode: ruby -*-
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/xenial64"
   # config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.provider "virtualbox" do |v|
     v.name   = "ansible-telegraf"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,7 @@
 - include: telegraf.yml
   tags: ["telegraf"]
   when: telegraf_enabled
+
+- include: smart.yml
+  tags: ["telegraf"]
+  #  when: "smart in telegraf_input and telegraf_enabled

--- a/tasks/smart.yml
+++ b/tasks/smart.yml
@@ -1,0 +1,21 @@
+- name: Installs smartmontools 
+  apt:
+    pkg: smartmontools
+    state: present
+  ignore_errors: true
+  when: smart in telegraf_inputs
+
+    #- name: Adds telegraf to sudoers
+    #  user:
+    #    name: telegraf
+    #    groups: sudo 
+
+- name: Install sudoers config to execute smartctl without password for telegraf
+  template:
+    src: 30-telegraf-smart.j2
+    dest: "/etc/sudoers.d/30-telegraf-smart"
+    mode: 0440
+    group: root
+    owner: root
+  ignore_errors: true
+  when: smart in telegraf_inputs

--- a/templates/30-telegraf-smart.j2
+++ b/templates/30-telegraf-smart.j2
@@ -1,0 +1,1 @@
+telegraf ALL=(ALL:ALL) NOPASSWD: /usr/sbin/smartctl


### PR DESCRIPTION
Ajout du support de smart dans les inputs : 

- installation de smartmontools
- ajout de l'autorisation de telegraf à executer smartctl as root et sans mot de passe